### PR TITLE
Support for local IDE execution and latest Gatling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'scala'
     // The following line allows to load io.gatling.gradle plugin and directly apply it
-    id 'io.gatling.gradle' version '3.8.2'
+    id 'io.gatling.gradle' version '3.8.3.2'
 }
 
 gatling {

--- a/src/gatling/scala/IDEPathHelper.scala
+++ b/src/gatling/scala/IDEPathHelper.scala
@@ -2,7 +2,7 @@ import java.nio.file.{Path, Paths}
 
 object IDEPathHelper {
 
-  private val projectRootDir = Paths.get(getClass.getClassLoader.getResource("gatling.conf").toURI).getParent.getParent.getParent
+  private val projectRootDir = Paths.get(getClass.getClassLoader.getResource("gatling.conf").toURI).getParent.getParent.getParent.getParent
   private val gradleBuildDirectory = projectRootDir.resolve("build")
   private val gradleSrcDirectory = projectRootDir.resolve("src").resolve("gatling")
 


### PR DESCRIPTION
Modified the IDEPathHelper to support execution from local IDE and updated to latest Gatling 3.8.3.2